### PR TITLE
fixed error on undefined variable

### DIFF
--- a/getusers.php
+++ b/getusers.php
@@ -56,11 +56,13 @@ if(isloggedin()) {
 		$availability = $DB->get_field('course_modules', "availability", array("course"=>$course_id, "instance"=>$forum_id, 'module'=>$moduleid));
 		$restrictions = json_decode($availability)->c;
 
-		foreach ($restrictions as $restriction) {
-			if ($restriction->type == 'group') {
-				$group_id = $restriction->id;
-			} elseif ($restriction->type == 'grouping') {
-				$grouping_id = $restriction->id;
+		if (isset($restrictions)) {
+			foreach ($restrictions as $restriction) {
+				if ($restriction->type == 'group') {
+					$group_id = $restriction->id;
+				} elseif ($restriction->type == 'grouping') {
+					$grouping_id = $restriction->id;
+				}
 			}
 		}
 


### PR DESCRIPTION
There was an error popping up on New relic because if the restriction is not set an undefined variable was called